### PR TITLE
enabled mode switch so users can change to dark mode

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -68,7 +68,7 @@ module.exports = () => {
 
             colorMode: {
                 defaultMode: 'light',
-                disableSwitch: true,
+                disableSwitch: false,
                 respectPrefersColorScheme: false,
             },
 


### PR DESCRIPTION
Enabled `switch` so users can opt for dark mode.

![image](https://github.com/convisoappsec/conviso-docs/assets/78166970/ab293f01-e110-497e-8451-96a4f1e140d3)
![image](https://github.com/convisoappsec/conviso-docs/assets/78166970/d5430985-2c0b-4c35-925d-d8beafefe2e2)
