### PR TITLE
Add Vulnerability Auto Close to the CI/CD Code Snippets

### DIFF
--- a/docs/integrations/aws-codebuild.md
+++ b/docs/integrations/aws-codebuild.md
@@ -183,16 +183,8 @@ phases:
       - pip3 install conviso-cli
   pre_build:
     commands:
-      - conviso ast run
+      - conviso ast run --vulnerability-auto-close
 ```
-
-
-In the previously mentioned pipeline setup, the ```conviso ast run``` command is used without additional options. By default, this command analyzes the entire repository. This default behavior is due to the preset values for the ```--start-commit``` and ```--end-commit``` options which are set to the first commit and the current commit (HEAD), respectively.
-
-
-However, there is flexibility to customize the range of commits for analysis. For example, you can specifically scan the differences between the current commit and the one immediately preceding it on the current branch. This targeted approach ensures that the findings are restricted to the changes made in the latest commit.
-
-
 
 ## Troubleshooting
 

--- a/docs/integrations/azure-pipelines-cli.md
+++ b/docs/integrations/azure-pipelines-cli.md
@@ -70,7 +70,7 @@ jobs:
     - checkout: self
       persistCredentials: true
     - bash: |
-          conviso ast run
+          conviso ast run --vulnerability-auto-close
       displayName: 'Running Conviso AST'
       env:
          CONVISO_API_KEY: $(CONVISO_API_KEY)

--- a/docs/integrations/bitbucket-pipelines.md
+++ b/docs/integrations/bitbucket-pipelines.md
@@ -83,7 +83,7 @@ pipelines:
           name: Conviso BitBucket Pipeline
           script:
             - |
-                conviso ast run \
+                conviso ast run --vulnerability-auto-close \
           services:
             - docker
 ```
@@ -164,7 +164,7 @@ To view the company ID, click on the company logo icon, as exemplified in the im
 Example
 ```
    - export CONVISO_COMPANY_ID=0000
-   - conviso ast run
+   - conviso ast run --vulnerability-auto-close
 ```
 
 

--- a/docs/integrations/circleci.md
+++ b/docs/integrations/circleci.md
@@ -74,7 +74,7 @@ jobs:
       - checkout
       - run:
           name: "Conviso AST"
-          command: "conviso ast run"
+          command: "conviso ast run --vulnerability-auto-close"
 
 # Orchestrate jobs using workflows
 # See: https://circleci.com/docs/workflows/ & https://circleci.com/docs/configuration-reference/#workflows

--- a/docs/integrations/codefresh.md
+++ b/docs/integrations/codefresh.md
@@ -113,7 +113,7 @@ conviso_sample:
     type: "freestyle"
     image: "convisoappsec/convisocli"
     commands:
-      - "conviso ast run"
+      - "conviso ast run --vulnerability-auto-close"
     stage: "test"
     working_directory: "/codefresh/volume/${{CF_REPO_NAME}}"
 ```

--- a/docs/integrations/github-actions.md
+++ b/docs/integrations/github-actions.md
@@ -73,7 +73,7 @@ jobs:
    - uses: actions/checkout@v4
 
    - name: Run AST
-     run: conviso ast run
+     run: conviso ast run --vulnerability-auto-close
 ```
 
 The identified vulnerabilities will be automatically sent to your Asset on Conviso Platform. Now you can use the [Vulnerabilities](../platform/vulnerabilities) resource to work on the correction flow.
@@ -212,7 +212,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Run AST
-        run: conviso ast run
+        run: conviso ast run --vulnerability-auto-close
 ```
 
 ### Running the Workflow Manually

--- a/docs/integrations/gitlab.md
+++ b/docs/integrations/gitlab.md
@@ -58,7 +58,7 @@ conviso-ast:
         variables:
             - $CONVISO_API_KEY
     script:
-        - conviso ast run
+        - conviso ast run --vulnerability-auto-close
     tags:
         - docker
 

--- a/docs/integrations/jenkins.md
+++ b/docs/integrations/jenkins.md
@@ -63,7 +63,7 @@ pipeline {
   stages {
     stage('Conviso_AST') {
       steps {
-        sh 'conviso ast run'
+        sh 'conviso ast run --vulnerability-auto-close'
       }
     }
   }


### PR DESCRIPTION
This PR introduces the `--vulnerability-auto-close` argument to the CI/CD AST code snippets, enabling automatic closure of vulnerabilities during scans.