### PR TITLE
Remove GraphQL Introduction File

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -32,7 +32,6 @@ async function proxyPlugin() {
             schema: 'https://app.convisoappsec.com/graphql',
             rootPath: './docs',
             baseURL: 'api/graphql/documentation',
-            homepage: './docs/api/graphql/introduction.md',
             loaders: {
               UrlLoader: {
                 module: '@graphql-tools/url-loader',


### PR DESCRIPTION
This PR removes the GraphQL introduction file reference from `docusaurus.config.js` in order to fix the error encountered when running the `docusaurus graphql-to-doc` command.