### PR TITLE
Remove 'Deploy, aka code versions' section from CLI docs

### DIFF
--- a/docs/cli/ast.md
+++ b/docs/cli/ast.md
@@ -107,21 +107,6 @@ conviso sast run --vulnerability-auto-close
 
 This will perform the scan as it has always been done and as a last step it will validate with the Conviso Platform if any vulnerability has been fixed.
 
-### Deploy, aka code versions
-
-When running the AST scan using the CLI, a [Deploy](../guides/code-review-strategies) is automatically created and diff code will be sent to Conviso Platform security for later human review.
-
-<div style={{textAlign: 'center'}}>
-
-![img](../../static/img/cli-ast1.png 'Conviso Platform security Code Review')
-
-</div>
-
-It is possible to verify if the code added or changed in the commit has known security vulnerabilities and compare it with the original repository.
-
-**Note:** This feature is essential for performing Security Code Review by the security team. Conviso offers the continuous code review service, [see more](https://bit.ly/457M2Cb).
-
-
 ## Run scan only with Conviso SAST or SCA
 
 As an additional custom configuration of the Conviso CLI, it’s possible to perform SAST-only in your code using the following command:


### PR DESCRIPTION
## PR Description

The “Deploy, aka code versions” section has been removed from the CLI documentation because it is obsolete and refers to functionality that is no longer available or supported.

<img width="1857" height="1011" alt="image" src="https://github.com/user-attachments/assets/9fbe9dcd-0241-4a6e-9dad-d1628a9ca289" />
