### PR TITLE
[codex] make graphql docs optional in default builds

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -40,9 +40,10 @@ async function proxyPlugin() {
       },
     };
   
+    const enableGraphqlDocs = process.env.ENABLE_GRAPHQL_DOCS === 'true';
     let graphqlDocsPlugin = [];
 
-    try {
+    if (enableGraphqlDocs) {
       graphqlDocsPlugin = [
         [
           '@graphql-markdown/docusaurus',
@@ -63,8 +64,10 @@ async function proxyPlugin() {
           },
         ],
       ];
-    } catch (err) {
-      console.warn('[GraphQL Docs Plugin] Falha ao carregar schema. Ignorando...');
+    } else {
+      console.warn(
+        '[GraphQL Docs Plugin] Skipping remote schema loading. Set ENABLE_GRAPHQL_DOCS=true to regenerate GraphQL docs.'
+      );
     }
     
     return {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "deploy": "docusaurus deploy",
     "serve": "docusaurus serve",
     "clear": "docusaurus clear",
-    "doc": "docusaurus graphql-to-doc --force",
+    "doc": "ENABLE_GRAPHQL_DOCS=true docusaurus graphql-to-doc --force",
     "doc:clean": "rm -rf docs/api/graphql/documentation/*",
     "screenshot:install": "playwright install chromium",
     "screenshot:auth": "node scripts/save-auth-session.mjs",


### PR DESCRIPTION
## What changed
- made the GraphQL docs plugin opt-in instead of loading during every default Docusaurus build
- added an explicit `ENABLE_GRAPHQL_DOCS=true` flag to the `yarn doc` script so schema introspection only runs when intentionally regenerating GraphQL docs
- kept the rest of the site build independent from the remote GraphQL schema endpoint

## Why
The deploy workflow was failing on `main` during the documentation build because the GraphQL docs plugin attempted remote schema introspection and received:

- `GraphQLError: GraphqlController - An error occurred`

That external dependency should not block the standard site build and S3 deploy.

## Impact
- normal builds and deploys no longer depend on remote GraphQL schema availability
- GraphQL reference generation remains available through the dedicated `yarn doc` command
- existing generated GraphQL docs already committed in the repository continue to be served normally

## Validation
- inspected the failing GitHub Actions logs for run `24835255336`
- confirmed the failure occurred in the `Generate docs` phase while loading the remote GraphQL schema
- verified locally that loading `docusaurus.config.js` without `ENABLE_GRAPHQL_DOCS=true` skips remote schema loading and completes successfully
