### PR TITLE
Fix Docusaurus doc context usage in theme overrides

### DIFF
--- a/src/theme/DocItem/Content/index.js
+++ b/src/theme/DocItem/Content/index.js
@@ -6,7 +6,12 @@ import ContributionCTA from "@site/src/components/ContributionCTA/ContributionCT
 import ResourcesFooter from "@site/src/components/ResourcesFooter/ResourcesFooter";
 
 export default function DocItemContent(props) {
-  const { metadata } = useDoc();
+  let metadata = null;
+  try {
+    metadata = useDoc()?.metadata ?? null;
+  } catch (error) {
+    metadata = null;
+  }
   const { pathname } = useLocation();
   const hideExtras =
     metadata?.unversionedId === "index" ||

--- a/src/theme/DocPaginator/index.js
+++ b/src/theme/DocPaginator/index.js
@@ -4,9 +4,16 @@ import { useDoc } from "@docusaurus/plugin-content-docs/client";
 import { useLocation } from "@docusaurus/router";
 
 export default function DocPaginatorWrapper(props) {
-  const { metadata } = useDoc();
+  let metadata = null;
+  try {
+    metadata = useDoc()?.metadata ?? null;
+  } catch (error) {
+    metadata = null;
+  }
   const { pathname } = useLocation();
+  const hasDocContext = Boolean(metadata);
   const hidePaginator =
+    !hasDocContext ||
     metadata?.unversionedId === "index" ||
     pathname === "/" ||
     pathname === "/index" ||


### PR DESCRIPTION
## What changed

This PR fixes the theme overrides for documentation pages that are rendered outside a Docusaurus `DocProvider`, such as generated category index pages.

## Root cause

The custom overrides in:

- `src/theme/DocPaginator/index.js`
- `src/theme/DocItem/Content/index.js`

called `useDoc()` unconditionally.

After the sidebar reorganization introduced a generated category page for `Application Lifecycle Management`, the build started rendering `/category/application-lifecycle-management` during static site generation. That route does not provide a doc context, so the hook threw:

`Hook useDoc is called outside the <DocProvider>.`

## Fix

- guard `useDoc()` access in both theme overrides
- fall back safely when the page is not a doc page
- hide the paginator when no doc context is available

## Validation

- reproduced the failure from the GitHub Actions logs
- ran `yarn build` locally
- build completed successfully with:
  - `[SUCCESS] Generated static files in "build".`
