### PR TITLE
chore: reuse create-pull-request workflow and upgrade checkout to v6

### DIFF
--- a/.github/workflows/security_test_suite.yml
+++ b/.github/workflows/security_test_suite.yml
@@ -12,7 +12,7 @@ jobs:
         CONVISO_API_KEY: ${{secrets.CONVISO_API_KEY}}
         CONVISO_COMPANY_ID: '11'
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
 
       - name: Diplay current version
         run: conviso --version


### PR DESCRIPTION
Update workflow files to use actions/checkout@v6 and reuse the centralized create-pull-request workflow template.