### PR TITLE
docs(integrations): document the Conviso AST Azure task and the GitHub sync task

### DIFF
--- a/docs/integrations/azure-pipelines-cli.md
+++ b/docs/integrations/azure-pipelines-cli.md
@@ -80,6 +80,44 @@ jobs:
 
 The identified vulnerabilities will be automatically sent the new Asset created on Conviso Platform. 
 
+## Running Conviso AST with the Azure DevOps task
+
+Instead of running the CLI inside a container job, you can add the **Conviso AST** task from the Azure DevOps Marketplace. A single task covers Static Application Security Testing (SAST), Software Composition Analysis (SCA), Infrastructure as Code (IaC), Software Bill of Materials (SBOM), secret and container scanning, and it resolves the branch, the sources directory and the output location from the pipeline itself. To configure it, follow these steps:
+
+1. Access the Azure DevOps Marketplace.
+2. Search for **Conviso AST** or directly visit [this link](https://marketplace.visualstudio.com/items?itemName=Conviso.convisoAstTask).
+3. Click on **Get it free**.
+4. Edit Your Azure DevOps Pipeline.
+5. Configure the Pipeline with the Following Code:
+```yaml
+steps:
+  - checkout: self
+
+  - task: ConvisoAST@1
+    displayName: Conviso AST
+    inputs:
+      apiKey: $(CONVISO_API_KEY)
+      companyId: 'your-company-id'
+```
+6. Save it and run the pipeline.
+
+**Field Descriptions**:
+- apiKey: Your [Conviso API Key](../api/api-overview.md#generate-api-key), referenced as `$(CONVISO_API_KEY)` in the pipeline variables. Always store it as a secret variable.
+- companyId: Your company ID in the Conviso Platform.
+- scanTypes: Which scan types to run — `sast`, `sca`, `iac`, `sbom`, `secret`, `container`. Optional; leave it empty to run all of them.
+- imageName: The image analyzed by the `container` scan (e.g. `myorg/app:$(Build.BuildId)`). Optional, and the `container` scan is skipped without it.
+- baselineRef: Branch to compare against so only what changed is scanned, such as `main` or `$(System.PullRequest.TargetBranch)`. Optional, and it requires `fetchDepth: 0` on the checkout step.
+- assetId: Pins the scan to a specific asset, skipping the automatic lookup by repository URL. Optional; use it if a scan stops with an asset ambiguity error.
+
+**Expected Behaviors**:
+- **Branch association**: The scan is recorded against the branch the build is for. In a **Pull Request** build, this is the branch the PR is coming **from**, so its findings are not filed under the target branch.
+- **Findings never fail the build**: The task fails only when a scan or an upload fails. Add `continueOnError: true` to the step if you do not want even that to stop the pipeline.
+- **Session archive**: Every run writes a zip with the raw output of each scan and the debug log to `$(Agent.TempDirectory)`. It is not published automatically — add a `PublishBuildArtifacts@1` step if you want to keep it, as it is the first artifact Conviso support asks for.
+
+:::note
+The task requires a **Linux x64** agent with Docker, such as `vmImage: ubuntu-latest`. If the agent already has the `conviso-ast` CLI and its scanner binaries installed, the task uses them directly and no Docker is required.
+:::
+
 ## Running the Conviso Containers
 
 To perform the [Conviso Containers](../security-scans/conviso-containers/conviso-containers.md), you can use the example configuration below:

--- a/docs/integrations/azure-pipelines-graph.md
+++ b/docs/integrations/azure-pipelines-graph.md
@@ -82,6 +82,48 @@ docker run --rm \
 
 3. The results will be sent to Conviso Platform.
 
+## Running Conviso AST with the Azure DevOps task
+
+Instead of the Bash task above, you can add the **Conviso AST** task from the Azure DevOps Marketplace. A single task covers Static Application Security Testing (SAST), Software Composition Analysis (SCA), Infrastructure as Code (IaC), Software Bill of Materials (SBOM), secret and container scanning, and it fills in the branch and the directory to scan from the pipeline itself. To configure it, follow these steps:
+
+1. Access the Azure DevOps Marketplace.
+2. Search for **Conviso AST** or directly visit [this link](https://marketplace.visualstudio.com/items?itemName=Conviso.convisoAstTask).
+3. Click on **Get it free**.
+4. Edit Your Azure DevOps Pipeline.
+5. In the **Pipeline variables** section, add the `CONVISO_API_KEY` variable and set its value to your [Conviso API Key](../api/api-overview.md#generate-api-key). Mark it as secret.
+6. Within the pipeline configuration, add the **Conviso AST** task.
+7. Fill in the fields as follows:
+   - Conviso API Key: `$(CONVISO_API_KEY)`.
+   - Company ID: Company ID in Conviso Platform.
+   - Scan types: **leave empty** to run every scan type, or select only the ones you need.
+   - Container image: the image analyzed by the container scan. Required only when you select **Container**, which is skipped without it.
+   - Path to scan and Branch: **leave both empty**. The task reads them from the pipeline itself — see [Repository context](#repository-context) below.
+8. Save the pipeline configuration and execute it to start the scan.
+
+**Expected Behaviors**:
+- **Branch association**: The scan is recorded against the branch the build is for. In a **Pull Request** build, this is the branch the PR is coming **from**, so its findings are not filed under the target branch.
+- **Findings never fail the build**: The task fails only when a scan or an upload fails, never because vulnerabilities were found.
+- **Session archive**: Every run writes a zip with the raw output of each scan and the debug log to the agent's temporary directory. Add a **Publish Build Artifacts** task if you want to keep it, as it is the first artifact Conviso support asks for.
+
+### Repository context
+
+Both fields below are optional, and both are filled in from the pipeline when you leave them empty,
+so the usual setup needs no extra configuration:
+
+| Field | Where it comes from when left empty |
+| --- | --- |
+| **Path to scan** | The directory the pipeline checked the sources out into |
+| **Branch** | The branch the build is for. In a **Pull Request** build, this is the branch the PR is **coming from**, not the branch it is merging into |
+
+Filling either field in overrides what the pipeline reports — use that only when the build does not
+run on the code you are tracking.
+
+:::note
+The task requires a **Linux x64** agent with Docker, such as the `ubuntu-latest` agent specification
+used in [First Steps](#first-steps). Unlike the Bash task above, it does not need the `DOCKER_HOST`
+variable.
+:::
+
 ## Running the Conviso Containers
 
 1. To perform the [Conviso Containers](../security-scans/conviso-containers/conviso-containers.md), you can use the example configuration below:

--- a/docs/integrations/github-actions.md
+++ b/docs/integrations/github-actions.md
@@ -323,6 +323,64 @@ jobs:
       run: conviso vulnerability assert-security-rules --rules-file 'security-gate.yml'
 ```
 
+## Importing and Synchronizing Assets from External Scanners
+
+Integrating the Conviso Platform with external scanners such as Checkmarx, Fortify, or Dependency-Track allows for automated asset import and synchronization. This ensures that your Conviso Platform remains up-to-date with the latest scan results. To configure this behavior, follow these steps:
+
+1. Add the `CONVISO_API_KEY` secret to your repository, with your [Conviso API Key](../api/api-overview.md#generate-api-key) as its value. Keep it in a repository or organization secret: anything written literally in the workflow file is readable by everyone who can read the repository.
+2. Create or edit a workflow file under `.github/workflows/`.
+3. Configure the Workflow with the Following Code:
+```yaml
+name: Sync to Conviso
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  conviso-sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: convisoappsec/github-sync-task@v1
+        with:
+          api-key: ${{secrets.CONVISO_API_KEY}}
+          project-id: 'external-tool-project-id'
+          integration: 'FORTIFY' # or 'DEPENDENCY_TRACK' or 'CHECKMARX'
+          company-id: 'your-company-id'
+```
+4. Commit the workflow and run it.
+
+**Field Descriptions**:
+- api-key: Your [Conviso API Key](../api/api-overview.md#generate-api-key), referenced from the repository secrets.
+- project-id: The project ID from the external scanner (e.g., Fortify, Checkmarx, Dependency-Track).
+- integration: The name of the integration as specified in Conviso's GraphQL schema (e.g., 'FORTIFY', 'CHECKMARX', 'DEPENDENCY_TRACK').
+- company-id: Your company ID in the Conviso Platform.
+- repository-url: The repository this scan belongs to. Optional; it defaults to the repository the workflow runs in — see [Repository and branch](#repository-and-branch) below.
+- branch: The branch this scan covers. Optional; it defaults to the branch that triggered the run.
+
+**Outputs**: the action exposes `asset-id` and `asset-name`, so a later step can reference the asset it associated.
+
+**Expected Behaviors**:
+- **Importing a New Project**: If the external scanner's project does not exist in the Conviso Platform, it will be imported as a new asset.
+- **Synchronizing an Existing Project**: If the project already exists in the Conviso Platform, it will be synchronized to update its data.
+
+In both scenarios, the process is triggered by the workflow and executed asynchronously. You can monitor the progress directly within the respective asset on the Conviso Platform.
+
+### Repository and branch
+
+The action also reports **which repository and which branch** the run is for. Both are optional
+inputs, and both are filled in from the workflow when you leave them empty, so the usual setup
+needs no extra YAML:
+
+| Input | Where it comes from when left empty |
+| --- | --- |
+| `repository-url` | The repository the workflow is running in |
+| `branch` | The branch that triggered the run. On a **pull request** event, this is the branch the PR is **merging into**, not the source branch |
+
+Setting `repository-url` turns the asset in Conviso Platform into a repository, and the asset is
+then named after the repository (`org/repo`) instead of the scanner's project name. The `branch`
+input only takes effect together with it — on its own, Conviso Platform ignores the branch.
+
 ## Troubleshooting
 
 ### Enabling External Actions for GitHub Actions

--- a/docs/integrations/github-actions.md
+++ b/docs/integrations/github-actions.md
@@ -327,9 +327,11 @@ jobs:
 
 Integrating the Conviso Platform with external scanners such as Checkmarx, Fortify, or Dependency-Track allows for automated asset import and synchronization. This ensures that your Conviso Platform remains up-to-date with the latest scan results. To configure this behavior, follow these steps:
 
-1. Add the `CONVISO_API_KEY` secret to your repository, with your [Conviso API Key](../api/api-overview.md#generate-api-key) as its value. Keep it in a repository or organization secret: anything written literally in the workflow file is readable by everyone who can read the repository.
-2. Create or edit a workflow file under `.github/workflows/`.
-3. Configure the Workflow with the Following Code:
+1. Access the GitHub Marketplace.
+2. Search for **Conviso GitHub Sync Task** or directly visit [this link](https://github.com/marketplace/actions/conviso-github-sync-task).
+3. Add the `CONVISO_API_KEY` secret to your repository, with your [Conviso API Key](../api/api-overview.md#generate-api-key) as its value. Keep it in a repository or organization secret: anything written literally in the workflow file is readable by everyone who can read the repository.
+4. Create or edit a workflow file under `.github/workflows/`.
+5. Configure the Workflow with the Following Code:
 ```yaml
 name: Sync to Conviso
 
@@ -348,7 +350,7 @@ jobs:
           integration: 'FORTIFY' # or 'DEPENDENCY_TRACK' or 'CHECKMARX'
           company-id: 'your-company-id'
 ```
-4. Commit the workflow and run it.
+6. Commit the workflow and run it.
 
 **Field Descriptions**:
 - api-key: Your [Conviso API Key](../api/api-overview.md#generate-api-key), referenced from the repository secrets.


### PR DESCRIPTION
## What

Documents two tasks that are usable today but had no page here:

- **Conviso AST** — the Azure Pipelines task, added to both Azure pages (`azure-pipelines-cli` and `azure-pipelines-graph`)
- **Conviso GitHub Sync Task** — the GitHub Actions port of the Azure sync task, added to `github-actions`

Each new section follows the structure the **Conviso Azure Sync Task** already uses on these pages: numbered setup steps, a copy-pasteable snippet, **Field Descriptions**, **Expected Behaviors**. 138 lines added, none removed.

## Why the AST task appears twice

Azure Pipelines is documented once per editor. The YAML page gets the `ConvisoAST@1` step; the classic-editor page gets the field-by-field walkthrough, plus a **Repository context** subsection mirroring the **Repository and branch** one the sync task already has there.

Both explain that the branch and the path to scan come from the pipeline itself. That is the part that is easy to get wrong by hand — in a pull request build Azure reports `refs/pull/42/merge`, which is not a branch name — and it is the reason the task exists rather than a raw `docker run` step.

## One deviation from the surrounding pages

The new links point at `api-overview.md#generate-api-key`. The surrounding pages link the API key to `security-feed.md#generate-api-key`, and **that anchor does not exist** — the security feed page has no such heading. It is broken in 9 places across 6 files.

This PR does not fix those 9, since that is a separate change with its own blast radius. Happy to do it here if preferred.

## Marketplace listings

Both sections open with their listing, the way the Azure sync task's section already does. Both links were checked and return 200:

| Task | Listing |
| --- | --- |
| Conviso AST | https://marketplace.visualstudio.com/items?itemName=Conviso.convisoAstTask |
| Conviso GitHub Sync Task | https://github.com/marketplace/actions/conviso-github-sync-task |

## Notes

- Scan types are described by what they cover, not by the engine behind them, matching #617.
- No `sidebars.js` change — these are sections on pages already in the menu.
- `yarn build` could not be used to validate: `@docusaurus/theme-mermaid` is missing from the local `node_modules`, which fails the build on `main` too. Links and anchors were checked by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
