### PR TITLE
docs(conviso-dast): auto-close requires two consecutive scans

### DIFF
--- a/docs/security-scans/conviso-dast/conviso-dast.md
+++ b/docs/security-scans/conviso-dast/conviso-dast.md
@@ -50,7 +50,7 @@ Most real risk lives behind the login. Conviso DAST can scan **authenticated are
 
 ### Evidence and consolidation
 
-Every finding ships with the **real HTTP request and response** that proves it, plus severity, CWE, description, remediation guidance, and references. Results are automatically **deduplicated** and consolidated in the Conviso Platform, and a vulnerability that is no longer present is **automatically closed** on the next scan.
+Every finding ships with the **real HTTP request and response** that proves it, plus severity, CWE, description, remediation guidance, and references. Results are automatically **deduplicated** and consolidated in the Conviso Platform, and a vulnerability that is no longer present is **automatically closed** once two consecutive scans stop reporting it.
 
 
 
@@ -146,7 +146,7 @@ You can also generate a detailed report of the scan execution from this page cli
 
 
 :::note
-When the vulnerability is fixed, running the next scan should identify it, and then change the vulnerability status to "Fixed" automatically.
+When the vulnerability is fixed, the scans that follow stop reporting it. After two consecutive scans without it, the Platform changes the vulnerability status to "Fixed" automatically — the second scan is what confirms the fix, so a single scan that misses the vulnerability never closes it on its own.
 :::
 
 With the above, you should be able to run DAST on the Conviso Platform.


### PR DESCRIPTION
## What

Corrects the DAST documentation on when a vulnerability is closed automatically. The
Platform now requires **two consecutive scans** to stop reporting a vulnerability before
closing it — the docs still described closing on the next scan.

## Why

A single scan can complete successfully and still have covered less than it should:
authentication expiring mid-run, a WAF starting to block, part of the application being
down. In those cases the vulnerability is missing from the results without having been
fixed. Requiring a second consecutive scan to confirm the absence keeps one degraded scan
from closing live vulnerabilities.

## Changes

`docs/security-scans/conviso-dast/conviso-dast.md`

- **Overview** — "automatically closed on the next scan" → "automatically closed once two
  consecutive scans stop reporting it".
- **Note after the scan setup** — rewritten to describe the two-scan confirmation, and to
  state explicitly that a single scan missing the vulnerability never closes it on its own.

The second sentence answers the question this behaviour raises in practice: "I ran a scan,
the vulnerability is gone, why is it still open?". Without it the behaviour reads as a bug.

The status name shown to users is unchanged.