### PR TITLE
docs(vulnerability-management): document severity and CVSS precedence

### DIFF
--- a/docs/vulnerability-management/process.md
+++ b/docs/vulnerability-management/process.md
@@ -133,16 +133,38 @@ prioritization, the asset [Risk Score](../platform/risk-score.md), the
 [Security Gate](../security-scans/security-gate.md) thresholds, and the
 [Remediation SLA](remediation-sla.md) deadline.
 
-A severity can arrive from three places: the tool that reported the finding
-(scanner, integration, or CLI), the analyst who registered or edited it manually,
-or a CVSS assessment attached to the vulnerability.
+A severity can come from three places: the tool that reported the finding
+(scanner, integration, or CLI), the **Impact** and **Probability** levels chosen
+when the vulnerability is registered manually, or a **CVSS** assessment attached
+to the vulnerability. When more than one is available, CVSS wins.
+
+### Manual Registration: Impact × Probability
+
+Registering a vulnerability by hand does not mean typing a severity in. You pick
+two levels — **Impact** and **Probability**, each **Low**, **Medium**, or
+**High** — and the severity follows from the pair:
+
+| Impact ↓ / Probability → | Low          | Medium | High     |
+| ------------------------ | ------------ | ------ | -------- |
+| **Low**                  | Notification | Low    | Medium   |
+| **Medium**               | Low          | Medium | High     |
+| **High**                 | Medium       | High   | Critical |
+
+Behind the table, each level scores 1 (Low), 2 (Medium), or 3 (High) and the two
+are multiplied; the product selects the band. So the matrix is symmetric — Low
+impact with High probability and High impact with Low probability both land on
+Medium.
+
+Editing a vulnerability works the same way: change Impact or Probability and the
+severity is recomputed from the new pair.
 
 ### CVSS Takes Precedence Over the Reported Severity
 
 When a vulnerability carries a **CVSS** assessment, the platform derives the
-severity from the CVSS score and that derived value **wins over the severity
-label the tool sent** — and over a severity set by hand. This applies to every
-ingestion path: scanner integrations, the CLI, the API, and manual registration.
+severity from the CVSS score and that derived value **wins over the severity the
+tool sent** — and over the one computed from Impact × Probability. This applies to
+every ingestion path: scanner integrations, the CLI, the API, and manual
+registration.
 
 | CVSS score   | Severity in Conviso Platform |
 | ------------ | ---------------------------- |
@@ -152,9 +174,9 @@ ingestion path: scanner integrations, the CLI, the API, and manual registration.
 | 7.0 – 8.9    | High                         |
 | 9.0 – 10.0   | Critical                     |
 
-These are the CVSS qualitative rating bands (identical in v3.0, v3.1, and v4.0).
-CVSS calls the 0.0 band *None*; **Notification** is its counterpart in the
-platform.
+These are the CVSS qualitative rating bands, which are the same in **v3.1** and
+**v4.0**. CVSS calls the 0.0 band *None*; **Notification** is its counterpart in
+the platform.
 
 Details worth knowing:
 
@@ -166,11 +188,13 @@ Details worth knowing:
 * **The most specific score expressed by the vector is used** — Environmental
   when the vector carries Environmental metrics, Temporal when it carries only
   Temporal metrics, Base otherwise.
-* **Findings without a CVSS keep the severity that was assigned to them** by the
-  tool or by the analyst. Precedence only kicks in when a CVSS is present.
-* **While a CVSS is set, editing the severity by hand has no effect** — it is
-  re-derived on every save. Clear the CVSS to make the severity editable again;
-  clearing it keeps the last derived severity instead of wiping it.
+* **Findings without a CVSS keep the severity that was assigned to them** — by
+  the tool, or by the Impact × Probability pair. Precedence only kicks in when a
+  CVSS is present.
+* **While a CVSS is set, changing Impact or Probability no longer moves the
+  severity** — it is re-derived from the CVSS on every save. Clear the CVSS to put
+  the matrix back in control; clearing it keeps the last derived severity instead
+  of wiping it.
 * **The SLA deadline follows.** Because the deadline is computed from severity, a
   CVSS that changes the severity also recomputes the deadline — anchored on the
   vulnerability's original creation date, not on the date the CVSS was added. See

--- a/docs/vulnerability-management/process.md
+++ b/docs/vulnerability-management/process.md
@@ -125,6 +125,65 @@ In the vulnerability list, issues are grouped by title, asset, and type. This ma
 
 4. The right-hand column displays details for the selected occurrence, including ID, severity, status, source, vulnerable file and lines, code snippet, timeline, and attachments.
 
+## Vulnerability Severity
+
+Every vulnerability carries one of five severities: **Critical**, **High**,
+**Medium**, **Low**, and **Notification** (informational). Severity drives
+prioritization, the asset [Risk Score](../platform/risk-score.md), the
+[Security Gate](../security-scans/security-gate.md) thresholds, and the
+[Remediation SLA](remediation-sla.md) deadline.
+
+A severity can arrive from three places: the tool that reported the finding
+(scanner, integration, or CLI), the analyst who registered or edited it manually,
+or a CVSS assessment attached to the vulnerability.
+
+### CVSS Takes Precedence Over the Reported Severity
+
+When a vulnerability carries a **CVSS** assessment, the platform derives the
+severity from the CVSS score and that derived value **wins over the severity
+label the tool sent** — and over a severity set by hand. This applies to every
+ingestion path: scanner integrations, the CLI, the API, and manual registration.
+
+| CVSS score   | Severity in Conviso Platform |
+| ------------ | ---------------------------- |
+| 0.0          | Notification                 |
+| 0.1 – 3.9    | Low                          |
+| 4.0 – 6.9    | Medium                       |
+| 7.0 – 8.9    | High                         |
+| 9.0 – 10.0   | Critical                     |
+
+These are the CVSS qualitative rating bands (identical in v3.0, v3.1, and v4.0).
+CVSS calls the 0.0 band *None*; **Notification** is its counterpart in the
+platform.
+
+Details worth knowing:
+
+* **The CVSS vector is the canonical input.** When a tool sends both a vector and
+  a score, the score is recomputed from the vector rather than trusted as
+  received, so a tool that reports a score inconsistent with its own vector does
+  not skew the severity. A tool that sends only a score (no vector) has that
+  score used as-is.
+* **The most specific score expressed by the vector is used** — Environmental
+  when the vector carries Environmental metrics, Temporal when it carries only
+  Temporal metrics, Base otherwise.
+* **Findings without a CVSS keep the severity that was assigned to them** by the
+  tool or by the analyst. Precedence only kicks in when a CVSS is present.
+* **While a CVSS is set, editing the severity by hand has no effect** — it is
+  re-derived on every save. Clear the CVSS to make the severity editable again;
+  clearing it keeps the last derived severity instead of wiping it.
+* **The SLA deadline follows.** Because the deadline is computed from severity, a
+  CVSS that changes the severity also recomputes the deadline — anchored on the
+  vulnerability's original creation date, not on the date the CVSS was added. See
+  [Remediation SLA](remediation-sla.md#the-sla-deadline).
+
+:::note
+The **Severity Filters** / **Severity Mapping** step of an integration is a
+different thing from precedence: it selects **which findings are imported**, based
+on the severity the tool reports. CVSS derivation happens afterwards, when the
+finding is created in the platform. So a finding is imported under the tool's own
+label and may then be displayed at a different severity.
+:::
+
 ## Update Vulnerability Status
 
 To update the status of a vulnerability, check how many lines are selected in the "Occurrences" table. In the image below, **two vulnerabilities are selected (1)**. Then, **click on the current status of the vulnerability (2)** and **select the new status (3)**:

--- a/docs/vulnerability-management/remediation-sla.md
+++ b/docs/vulnerability-management/remediation-sla.md
@@ -16,6 +16,13 @@ it is computed from a **matrix** that combines two dimensions:
 * the **severity** of the vulnerability (Critical, High, Medium, Low); and
 * the **business impact** of the asset where it was found (High, Medium, Low).
 
+:::note
+When a vulnerability carries a CVSS assessment, its severity is derived from the
+CVSS score and overrides the severity the reporting tool sent — so the SLA
+deadline follows the CVSS-derived band. See [Vulnerability
+Severity](process.md#vulnerability-severity).
+:::
+
 Each cell of the matrix holds a **time to fix, in days**. When a vulnerability is
 created, the platform looks up the cell that matches its severity and its asset's
 business impact, adds that many days to the date the vulnerability was created,


### PR DESCRIPTION
## Why

Severity had no canonical page in the docs. It showed up only as a filter option and as a field in the occurrence detail panel, and CVSS was never mentioned outside the Security Gate guide. So a reader who sees a finding displayed at a severity different from the one the reporting tool sent has no way to find out why.

## What changed

**`docs/vulnerability-management/process.md`** — new `## Vulnerability Severity` section:

- the five levels (Critical, High, Medium, Low, Notification) and what severity drives (prioritization, Risk Score, Security Gate thresholds, Remediation SLA);
- `### CVSS Takes Precedence Over the Reported Severity` — a CVSS assessment overrides the severity the tool sent *and* a severity set by hand, on every ingestion path (integrations, CLI, API, manual registration);
- the score → severity band table, with CVSS `0.0` (*None*) mapping to Notification;
- the CVSS **vector** is the canonical input — the score is recomputed from it rather than trusted as received; a score sent without a vector is used as-is;
- most specific score expressed by the vector wins: Environmental > Temporal > Base;
- findings with no CVSS keep their assigned severity; while a CVSS is set, editing severity by hand has no effect (clear the CVSS to edit it again, which keeps the last derived value);
- the SLA deadline follows a CVSS-driven severity change, anchored on the original creation date;
- a note separating an integration's **Severity Filters** / **Severity Mapping** step (selects *what gets imported*, using the tool's own label) from precedence (applied afterwards, at creation).

**`docs/vulnerability-management/remediation-sla.md`** — note in the Overview that the deadline follows the CVSS-derived band, linking to the new section.

Docs only — no screenshots needed.

## Verification

Behavior was read from `platform-backend`, not inferred from the UI:

- `app/models/concerns/issue/callbacks.rb` — `before_validation :derive_severity_from_cvss`, so precedence is model-level and applies to every write path; clearing the CVSS leaves severity at its last value.
- `app/services/conviso/issues/cvss_calculator.rb` — the band table and the Environmental > Temporal > Base rule.
- `app/services/conviso/issues/batch/row_builder.rb` — batch import reapplies the same rule (`insert_all!` skips callbacks), and prefers the vector-derived score over the score the tool sent.

Verified CVSS senders in that repo are Dependency Track, the SBOM NVD/OSV correlation, and MobSF (score only). Tenable, Salt Security, and Snyk ingestion lives outside `platform-backend`, so the docs deliberately do **not** name which integrations send CVSS.

## Follow-up worth discussing (not in this PR)

The current rule leaves an analyst no way to override a CVSS-derived severity except by deleting the CVSS — which discards data in order to change a display band. Since severity drives the SLA and the deadline is anchored on `created_at`, a CVSS added or corrected later can move a finding straight to Breached with no way to dispute it. A `severity_source` (`cvss` | `tool` | `manual`) that lets an explicit, attributed manual override win over CVSS would keep the cross-tool normalization while restoring analyst authority. Raising it here for the record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
